### PR TITLE
Owner only table to csv export subcommand

### DIFF
--- a/voxelbotutils/cogs/owner_only.py
+++ b/voxelbotutils/cogs/owner_only.py
@@ -618,8 +618,8 @@ class OwnerOnly(utils.Cog, command_attrs={'hidden': True}):
         await ctx.send(file=discord.File(filename))
         
         # And delete the file
-        if os.path.exists(f'./{filename}'):
-            os.remove(f'./{filename}')
+        if os.path.exists(filename):
+            os.remove(filename)
         else:
             return
 

--- a/voxelbotutils/cogs/owner_only.py
+++ b/voxelbotutils/cogs/owner_only.py
@@ -601,7 +601,7 @@ class OwnerOnly(utils.Cog, command_attrs={'hidden': True}):
         # Get the data we want to save
         async with self.bot.database() as db:
             await db.conn.copy_from_query('SELECT * FROM {table_name}'.format(table_name=table_name), output=filename, format='csv')
-            column_descs = await db('DESCRIBE TABLE {table}'.format(table=table))
+            column_descs = await db('DESCRIBE TABLE {table_name}'.format(table_name=table_name))
 
         # See what was written to the file
         with open(filename, 'r') as f:

--- a/voxelbotutils/cogs/owner_only.py
+++ b/voxelbotutils/cogs/owner_only.py
@@ -467,6 +467,7 @@ class OwnerOnly(utils.Cog, command_attrs={'hidden': True}):
         pass
 
     @export.command(cls=utils.Command, name="commands")
+    @commands.bot_has_permissions(send_messages=True, attach_files=True)
     @commands.is_owner()
     async def export_commands(self, ctx):
         """
@@ -501,6 +502,7 @@ class OwnerOnly(utils.Cog, command_attrs={'hidden': True}):
         await ctx.send(file=discord.File(io.StringIO('\n\n'.join(lines)), filename="commands.md"))
 
     @export.command(cls=utils.Command, name="guild")
+    @commands.bot_has_permissions(send_messages=True, attach_files=True)
     @commands.is_owner()
     async def export_guild(self, ctx, guild_id:int=None):
         """
@@ -587,6 +589,7 @@ class OwnerOnly(utils.Cog, command_attrs={'hidden': True}):
         await ctx.send(file=file)
     
     @export.command(cls=utils.Command, name="table")
+    @commands.bot_has_permissions(send_messages=True, attach_files=True)
     @commands.is_owner()
     async def export_table(self, ctx, table_name:str):
         """

--- a/voxelbotutils/cogs/owner_only.py
+++ b/voxelbotutils/cogs/owner_only.py
@@ -599,7 +599,7 @@ class OwnerOnly(utils.Cog, command_attrs={'hidden': True}):
             f.write("")
 
         # Get the data we want to save
-        async with bot.database() as db:
+        async with self.bot.database() as db:
             await db.conn.copy_from_query('SELECT * FROM {table_name}'.format(table_name=table_name), output=filename, format='csv')
             column_descs = await db('DESCRIBE TABLE {table}'.format(table=table))
 


### PR DESCRIPTION
Allows owners of bots to export a given table in a bots database to a csv file