### PR TITLE
Fixing a warning that says unexpected type when creating an actionrow.

### DIFF
--- a/voxelbotutils/cogs/utils/interactions/components/action_row.py
+++ b/voxelbotutils/cogs/utils/interactions/components/action_row.py
@@ -49,7 +49,7 @@ class MessageComponents(ComponentHolder):
         return [i.to_dict() for i in self.components]
 
     @classmethod
-    def from_dict(cls, data: list):
+    def from_dict(cls, data: dict):
         new_components = []
         for i in data:
             component_type = component_types.get(i['type'], BaseComponent)

--- a/voxelbotutils/cogs/utils/interactions/components/action_row.py
+++ b/voxelbotutils/cogs/utils/interactions/components/action_row.py
@@ -26,7 +26,7 @@ class ActionRow(ComponentHolder):
         }
 
     @classmethod
-    def from_dict(cls, data: dict):
+    def from_dict(cls, data: list):
         components = data.get("components", list())
         new_components = []
         for i in components:

--- a/voxelbotutils/cogs/utils/interactions/components/models.py
+++ b/voxelbotutils/cogs/utils/interactions/components/models.py
@@ -1,6 +1,7 @@
 import re
 import typing
 import json
+from voxelbotutils.cogs.utils.interactions.components.action_row import ActionRow
 
 import discord
 
@@ -81,7 +82,7 @@ class ComponentHolder(BaseComponent):
     A message component that holds other message components.
     """
 
-    def __init__(self, *components: typing.List[BaseComponent]):
+    def __init__(self, *components: typing.Union[BaseComponent, ActionRow]):
         """
         Args:
             *components: A list of the components that this component holder holds.

--- a/voxelbotutils/cogs/utils/interactions/components/models.py
+++ b/voxelbotutils/cogs/utils/interactions/components/models.py
@@ -1,8 +1,6 @@
 import re
 import typing
 import json
-from voxelbotutils.cogs.utils.interactions.components.action_row import ActionRow
-
 import discord
 
 
@@ -82,7 +80,7 @@ class ComponentHolder(BaseComponent):
     A message component that holds other message components.
     """
 
-    def __init__(self, *components: typing.Union[BaseComponent, ActionRow]):
+    def __init__(self, *components: BaseComponent):
         """
         Args:
             *components: A list of the components that this component holder holds.


### PR DESCRIPTION
Changed the ComponentHolder class to be `typing.Union[BaseComponent, ActionRow]` from `typing.List[BaseComponent]`. Easy kludge fix.