### PR TITLE
Solve Interaction failed for Paginator buttons

### DIFF
--- a/voxelbotutils/cogs/utils/paginator.py
+++ b/voxelbotutils/cogs/utils/paginator.py
@@ -143,7 +143,7 @@ class Paginator(object):
             # See if we want to bother paginating
             last_payload = payload
             if self.max_pages == 1:
-                return
+                break
 
             # Wait for reactions to be added by the user
             interaction = None


### PR DESCRIPTION
I'm pretty sure this is supposed to break the loop and then disable the components. With this just returning, it causes the components to not be disabled though the bot isn't listening anymore