### PR TITLE
Fix wrong execution time being displayed

### DIFF
--- a/voxelbotutils/cogs/owner_only.py
+++ b/voxelbotutils/cogs/owner_only.py
@@ -198,7 +198,7 @@ class OwnerOnly(vbu.Cog, command_attrs={'hidden': True, 'add_slash_command': Fal
         time_taken = end - start
         precision = "seconds"
         prefixes = ["milli", "micro", "nano", "pico"]
-        index = 1
+        index = 0
         while float(format(time_taken, ".3f")) < 10:
             time_taken *= 1_000
             precision = f"{prefixes[index]}seconds"


### PR DESCRIPTION
Index started at 1 for some reason
![image](https://user-images.githubusercontent.com/67605203/233834619-f62415df-eb89-4f46-9771-73ea44f00be4.png)
